### PR TITLE
Simplify devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,51 +1,7 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+// For format details, see https://aka.ms/devcontainer.json.
 {
-	"name": "Ocean Development Environment",
-
-	// python 3.11 on debian, with latest Ocean and optional packages
-	// source repo: https://github.com/dwavesystems/ocean-dev-docker
-	"image": "docker.io/dwavesys/ocean-dev:latest",
-
-	// install repo pip requirements (only if present) on content update
-	"updateContentCommand": "[ ! -r requirements.txt ] || pip install -r requirements.txt",
-
-	// forward/expose container services (relevant only when run locally)
-	"forwardPorts": [
-		// dwave-inspector web app
-		18000, 18001, 18002, 18003, 18004,
-		// OAuth connect redirect URIs
-		36000, 36001, 36002, 36003, 36004
-	],
-
-	"portsAttributes": {
-		"18000-18004": {
-			"label": "D-Wave Problem Inspector",
-			"requireLocalPort": true
-		},
-		"36000-36004": {
-			"label": "OAuth 2.0 authorization code redirect URI",
-			"requireLocalPort": true
-		}
-	},
-
-	// Configure tool-specific properties.
-	"customizations": {
-		// Configure properties specific to VS Code.
-		"vscode": {
-			// Set *default* container specific settings.json values on container create.
-			"settings": {
-				"workbench": {
-					"editorAssociations": {
-						"*.md": "vscode.markdown.preview.editor"
-					},
-					"startupEditor": "readme"
-				}
-			},
-			"extensions": [
-				"ms-python.python",
-				"ms-toolsai.jupyter"
-			]
-		}
-	}
+	// Debian stable with the second-latest Python, latest Ocean, and optional dev packages.
+	// Docker image source: https://github.com/dwavesystems/ocean-dev-docker.
+	// Devcontainer config: https://github.com/dwavesystems/ocean-devcontainer.
+	"image": "docker.io/dwavesys/ocean-dev:latest"
 }


### PR DESCRIPTION
Use a minimal devcontainer (now embedded in the image).

See https://github.com/dwavesystems/ocean-dev-docker/pull/28.